### PR TITLE
Replace Dexie bulkUpdate call when marking scores synced

### DIFF
--- a/__tests__/dexie-markScoresSynced.test.ts
+++ b/__tests__/dexie-markScoresSynced.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('dexie', () => {
+  class Dexie {
+    version() {
+      return { stores: () => {} };
+    }
+  }
+  return { default: Dexie, Table: class {} };
+});
+
+import { GolfDatabase } from '../lib/dexie';
+
+describe('markScoresSynced', () => {
+  it('updates synced flag for provided ids', async () => {
+    const db = new GolfDatabase();
+    db.offlineScores = {
+      where: vi.fn().mockReturnThis(),
+      anyOf: vi.fn().mockReturnThis(),
+      modify: vi.fn().mockResolvedValue(2)
+    } as any;
+
+    const result = await db.markScoresSynced([1, 2]);
+
+    expect(db.offlineScores.where).toHaveBeenCalledWith('id');
+    expect(db.offlineScores.anyOf).toHaveBeenCalledWith([1, 2]);
+    expect(db.offlineScores.modify).toHaveBeenCalledWith({ synced: true });
+    expect(result).toBe(2);
+  });
+
+  it('returns 0 when no ids provided', async () => {
+    const db = new GolfDatabase();
+    db.offlineScores = {
+      where: vi.fn(),
+      anyOf: vi.fn(),
+      modify: vi.fn()
+    } as any;
+
+    const result = await db.markScoresSynced([]);
+
+    expect(result).toBe(0);
+    expect(db.offlineScores.where).not.toHaveBeenCalled();
+  });
+});

--- a/lib/dexie.ts
+++ b/lib/dexie.ts
@@ -58,10 +58,13 @@ export class GolfDatabase extends Dexie {
 
   // Mark scores as synced
   async markScoresSynced(scoreIds: number[]) {
-    return await this.offlineScores.bulkUpdate(
-      scoreIds,
-      { synced: true }
-    );
+    if (scoreIds.length === 0) {
+      return 0;
+    }
+    return await this.offlineScores
+      .where('id')
+      .anyOf(scoreIds)
+      .modify({ synced: true });
   }
 
   // Get offline queue count


### PR DESCRIPTION
## Summary
- fix offline score sync by replacing invalid `bulkUpdate` call with `where().anyOf().modify`
- cover `markScoresSynced` with unit tests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run __tests__/dexie-markScoresSynced.test.ts`
- `npm run check` *(fails: Cannot find module 'virtual:pwa-register' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c00ba44c8325b34aa45bd44d316c