### PR TITLE
test: add negative index rotation check

### DIFF
--- a/__tests__/kiosk-utils.test.ts
+++ b/__tests__/kiosk-utils.test.ts
@@ -75,6 +75,13 @@ describe('Kiosk Utility Functions', () => {
       expect(rotate(0, sections)).toBe(1);
       expect(rotate(1, sections)).toBe(0);
     });
+
+    it('should normalize negative indices', () => {
+      const sections: SectionType[] = ['gross', 'net'];
+      const nextIndex = rotate(-1, sections);
+      expect(nextIndex).toBeGreaterThanOrEqual(0);
+      expect(nextIndex).toBeLessThan(sections.length);
+    });
   });
 
   describe('diffRows', () => {

--- a/client/src/lib/kiosk-utils.ts
+++ b/client/src/lib/kiosk-utils.ts
@@ -56,8 +56,11 @@ export function diffRows(prev: PlayerResult[], next: PlayerResult[]): Map<string
  * @returns Next section index
  */
 export function rotate(currentIndex: number, enabledSections: SectionType[]): number {
-  if (enabledSections.length === 0) return 0;
-  return (currentIndex + 1) % enabledSections.length;
+  const length = enabledSections.length;
+  if (length === 0) return 0;
+  // Normalize the current index to ensure it's within bounds before rotating
+  const normalized = ((currentIndex % length) + length) % length;
+  return (normalized + 1) % length;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add coverage for negative rotation indices
- normalize negative indices in kiosk rotation utility

## Testing
- `npx vitest run __tests__/kiosk-utils.test.ts`
- `npx vitest run` *(fails: Failed to resolve import "@/lib/utils" from "components/ui/card.tsx" in `__tests__/mobile-layout.test.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c235823c83259cc762c447288027