### PR TITLE
refactor: migrate api routes to neon

### DIFF
--- a/app/api/courses/[id]/route.ts
+++ b/app/api/courses/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from '@/lib/db';
+import { db } from '@/lib/db';
+import { courses } from '@shared/schema';
+import { eq } from 'drizzle-orm';
 
 export async function PUT(
   request: NextRequest,
@@ -8,17 +10,18 @@ export async function PUT(
   try {
     const data = await request.json();
     
-    const course = await prisma.course.update({
-      where: { id: params.id },
-      data: {
-        name: data.name,
-        par: data.par,
-        slope: data.slope,
-        rating: data.rating,
-      }
-    });
-    
-    return NextResponse.json(course);
+      const [course] = await db
+        .update(courses)
+        .set({
+          name: data.name,
+          par: data.par,
+          slope: data.slope,
+          rating: data.rating,
+        })
+        .where(eq(courses.id, params.id))
+        .returning();
+
+      return NextResponse.json(course);
   } catch (error) {
     console.error('Failed to update course:', error);
     return NextResponse.json(
@@ -33,9 +36,7 @@ export async function DELETE(
   { params }: { params: { id: string } }
 ) {
   try {
-    await prisma.course.delete({
-      where: { id: params.id }
-    });
+      await db.delete(courses).where(eq(courses.id, params.id));
     
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/api/courses/route.ts
+++ b/app/api/courses/route.ts
@@ -1,13 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from '@/lib/db';
+import { db } from '@/lib/db';
+import { courses } from '@shared/schema';
+import { desc } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
 
 export async function GET() {
   try {
-    const courses = await prisma.course.findMany({
-      orderBy: { createdAt: 'desc' }
-    });
-    
-    return NextResponse.json(courses);
+    const allCourses = await db
+      .select()
+      .from(courses)
+      .orderBy(desc(courses.createdAt));
+
+    return NextResponse.json(allCourses);
   } catch (error) {
     console.error('Failed to fetch courses:', error);
     return NextResponse.json(
@@ -21,16 +25,18 @@ export async function POST(request: NextRequest) {
   try {
     const data = await request.json();
     
-    const course = await prisma.course.create({
-      data: {
-        name: data.name,
-        par: data.par,
-        slope: data.slope,
-        rating: data.rating,
-      }
-    });
-    
-    return NextResponse.json(course, { status: 201 });
+      const [course] = await db
+        .insert(courses)
+        .values({
+          id: nanoid(),
+          name: data.name,
+          par: data.par,
+          slope: data.slope,
+          rating: data.rating,
+        })
+        .returning();
+
+      return NextResponse.json(course, { status: 201 });
   } catch (error) {
     console.error('Failed to create course:', error);
     return NextResponse.json(

--- a/app/api/groups/route.ts
+++ b/app/api/groups/route.ts
@@ -1,20 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from '@/lib/db';
+import { db } from '@/lib/db';
+import { groups, tournaments, courses } from '@shared/schema';
+import { desc, eq } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
 
 export async function GET() {
   try {
-    const groups = await prisma.group.findMany({
-      include: {
-        tournament: {
-          include: {
-            course: true
-          }
-        }
-      },
-      orderBy: { createdAt: 'desc' }
-    });
-    
-    return NextResponse.json(groups);
+      const rows = await db
+        .select({ group: groups, tournament: tournaments, course: courses })
+        .from(groups)
+        .innerJoin(tournaments, eq(groups.tournamentId, tournaments.id))
+        .innerJoin(courses, eq(tournaments.courseId, courses.id))
+        .orderBy(desc(groups.createdAt));
+
+      const data = rows.map(r => ({
+        ...r.group,
+        tournament: { ...r.tournament, course: r.course }
+      }));
+
+      return NextResponse.json(data);
   } catch (error) {
     console.error('Failed to fetch groups:', error);
     return NextResponse.json(
@@ -28,22 +32,30 @@ export async function POST(request: NextRequest) {
   try {
     const data = await request.json();
     
-    const group = await prisma.group.create({
-      data: {
-        name: data.name,
-        tournamentId: data.tournamentId,
-        teeTime: data.teeTime ? new Date(data.teeTime) : null,
-      },
-      include: {
-        tournament: {
-          include: {
-            course: true
-          }
-        }
-      }
-    });
-    
-    return NextResponse.json(group, { status: 201 });
+      const [group] = await db
+        .insert(groups)
+        .values({
+          id: nanoid(),
+          name: data.name,
+          tournamentId: data.tournamentId,
+          teeTime: data.teeTime ? new Date(data.teeTime) : null,
+        })
+        .returning();
+
+      const tournament = await db
+        .select({ tournament: tournaments, course: courses })
+        .from(tournaments)
+        .innerJoin(courses, eq(tournaments.courseId, courses.id))
+        .where(eq(tournaments.id, group.tournamentId))
+        .limit(1);
+
+      return NextResponse.json(
+        {
+          ...group,
+          tournament: { ...tournament[0].tournament, course: tournament[0].course }
+        },
+        { status: 201 }
+      );
   } catch (error) {
     console.error('Failed to create group:', error);
     return NextResponse.json(

--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -1,13 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from '../../../lib/db';
+import { db } from '@/lib/db';
+import { players } from '@shared/schema';
+import { desc } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
 
 export async function GET() {
   try {
-    const players = await prisma.player.findMany({
-      orderBy: { createdAt: 'desc' }
-    });
-    
-    return NextResponse.json(players);
+    const allPlayers = await db
+      .select()
+      .from(players)
+      .orderBy(desc(players.createdAt));
+
+    return NextResponse.json(allPlayers);
   } catch (error) {
     console.error('Failed to fetch players:', error);
     return NextResponse.json(
@@ -21,15 +25,17 @@ export async function POST(request: NextRequest) {
   try {
     const data = await request.json();
     
-    const player = await prisma.player.create({
-      data: {
-        name: data.name,
-        email: data.email || null,
-        handicapIndex: data.handicapIndex || null,
-      }
-    });
-    
-    return NextResponse.json(player, { status: 201 });
+      const [player] = await db
+        .insert(players)
+        .values({
+          id: nanoid(),
+          name: data.name,
+          email: data.email || null,
+          handicapIndex: data.handicapIndex || null,
+        })
+        .returning();
+
+      return NextResponse.json(player, { status: 201 });
   } catch (error) {
     console.error('Failed to create player:', error);
     return NextResponse.json(

--- a/app/api/tournaments/[id]/route.ts
+++ b/app/api/tournaments/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from '@/lib/db';
+import { db } from '@/lib/db';
+import { tournaments, courses } from '@shared/schema';
+import { eq } from 'drizzle-orm';
 
 export async function PUT(
   request: NextRequest,
@@ -8,24 +10,28 @@ export async function PUT(
   try {
     const data = await request.json();
     
-    const tournament = await prisma.tournament.update({
-      where: { id: params.id },
-      data: {
-        name: data.name,
-        date: data.date,
-        courseId: data.courseId,
-        netAllowance: data.netAllowance,
-        passcode: data.passcode,
-        potAmount: data.potAmount || null,
-        participantsForSkins: data.participantsForSkins || null,
-        skinsCarry: data.skinsCarry || false,
-      },
-      include: {
-        course: true
-      }
-    });
-    
-    return NextResponse.json(tournament);
+      const [tournament] = await db
+        .update(tournaments)
+        .set({
+          name: data.name,
+          date: data.date,
+          courseId: data.courseId,
+          netAllowance: data.netAllowance,
+          passcode: data.passcode,
+          potAmount: data.potAmount ?? null,
+          participantsForSkins: data.participantsForSkins ?? null,
+          skinsCarry: data.skinsCarry ?? false,
+        })
+        .where(eq(tournaments.id, params.id))
+        .returning();
+
+      const course = await db
+        .select()
+        .from(courses)
+        .where(eq(courses.id, tournament.courseId))
+        .limit(1);
+
+      return NextResponse.json({ ...tournament, course: course[0] });
   } catch (error) {
     console.error('Failed to update tournament:', error);
     return NextResponse.json(
@@ -40,9 +46,7 @@ export async function DELETE(
   { params }: { params: { id: string } }
 ) {
   try {
-    await prisma.tournament.delete({
-      where: { id: params.id }
-    });
+      await db.delete(tournaments).where(eq(tournaments.id, params.id));
     
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/api/tournaments/route.ts
+++ b/app/api/tournaments/route.ts
@@ -1,16 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from '@/lib/db';
+import { db } from '@/lib/db';
+import { tournaments, courses } from '@shared/schema';
+import { desc, eq } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
 
 export async function GET() {
   try {
-    const tournaments = await prisma.tournament.findMany({
-      include: {
-        course: true
-      },
-      orderBy: { createdAt: 'desc' }
-    });
-    
-    return NextResponse.json(tournaments);
+      const rows = await db
+        .select({ tournament: tournaments, course: courses })
+        .from(tournaments)
+        .innerJoin(courses, eq(tournaments.courseId, courses.id))
+        .orderBy(desc(tournaments.createdAt));
+
+      const data = rows.map(r => ({ ...r.tournament, course: r.course }));
+
+      return NextResponse.json(data);
   } catch (error) {
     console.error('Failed to fetch tournaments:', error);
     return NextResponse.json(
@@ -24,24 +28,29 @@ export async function POST(request: NextRequest) {
   try {
     const data = await request.json();
     
-    const tournament = await prisma.tournament.create({
-      data: {
-        name: data.name,
-        date: data.date,
-        courseId: data.courseId,
-        holes: 18, // Fixed to 18 holes per requirements
-        netAllowance: data.netAllowance,
-        passcode: data.passcode,
-        potAmount: data.potAmount || null,
-        participantsForSkins: data.participantsForSkins || null,
-        skinsCarry: data.skinsCarry || false,
-      },
-      include: {
-        course: true
-      }
-    });
-    
-    return NextResponse.json(tournament, { status: 201 });
+      const [tournament] = await db
+        .insert(tournaments)
+        .values({
+          id: nanoid(),
+          name: data.name,
+          date: data.date,
+          courseId: data.courseId,
+          holes: 18,
+          netAllowance: data.netAllowance,
+          passcode: data.passcode,
+          potAmount: data.potAmount ?? null,
+          participantsForSkins: data.participantsForSkins ?? null,
+          skinsCarry: data.skinsCarry ?? false,
+        })
+        .returning();
+
+      const course = await db
+        .select()
+        .from(courses)
+        .where(eq(courses.id, tournament.courseId))
+        .limit(1);
+
+      return NextResponse.json({ ...tournament, course: course[0] }, { status: 201 });
   } catch (error) {
     console.error('Failed to create tournament:', error);
     return NextResponse.json(

--- a/client/src/lib/db.ts
+++ b/client/src/lib/db.ts
@@ -1,9 +1,1 @@
-import { PrismaClient } from '@prisma/client';
-
-const globalForPrisma = globalThis as unknown as {
-  prisma: PrismaClient | undefined;
-};
-
-export const prisma = globalForPrisma.prisma ?? new PrismaClient();
-
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+export { db } from '../../../lib/db';


### PR DESCRIPTION
## Summary
- replace Prisma with Drizzle/Neon in Next.js API routes for courses, players, tournaments and groups
- expose Neon-backed Drizzle instance to client code

## Testing
- `npm run check` *(fails: Cannot find module 'cors', Prisma references remain in server/routes.ts, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68b391d51c10832da6861d6787fbb1a5